### PR TITLE
use subJournal and subJournalISO in subArticle

### DIFF
--- a/pubrunner/convert.py
+++ b/pubrunner/convert.py
@@ -414,7 +414,7 @@ def processPMCFile(pmcFile):
 					backText = extractTextFromElemList(articleElem.findall('./back'))
 					floatingText = extractTextFromElemList(articleElem.findall('./floats-group'))
 					
-					document = {'pmid':subPmidText, 'pmcid':subPmcidText, 'doi':subDoiText, 'pubYear':subPubYear, 'pubMonth':subPubMonth, 'pubDay':subPubDay, 'journal':journal, 'journalISO':journalISO}
+					document = {'pmid':subPmidText, 'pmcid':subPmcidText, 'doi':subDoiText, 'pubYear':subPubYear, 'pubMonth':subPubMonth, 'pubDay':subPubDay, 'journal':subJournal, 'journalISO':subJournalISO}
 
 					textSources = {}
 					textSources['title'] = titleText


### PR DESCRIPTION
Cloned the repo and noticed those variables weren't being used.